### PR TITLE
Docs & tests for rejectWithValue

### DIFF
--- a/docs/api/createAsyncThunk.md
+++ b/docs/api/createAsyncThunk.md
@@ -91,7 +91,7 @@ When dispatched, the thunk will:
 - call the `payloadCreator` callback and wait for the returned promise to settle
 - when the promise settles:
   - if the promise resolved successfully, dispatch the `fulfilled` action with the promise value as `action.payload`
-  - if the promise resolved successfully or failed, but was returned with `rejectWithValue(value)`, dispatch the `rejected` action with the value passed into `action.payload`  and 'Rejected' as `action.error.message`
+  - if the promise resolved successfully or failed, but was returned with `rejectWithValue(value)`, dispatch the `rejected` action with the value passed into `action.payload` and 'Rejected' as `action.error.message`
   - if the promise failed and was not handled with `rejectWithValue`, dispatch the `rejected` action with a serialized version of the error value as `action.error`
 - Return a fulfilled promise containing the final dispatched action (either the `fulfilled` or `rejected` action object)
 
@@ -397,7 +397,7 @@ const updateUser = createAsyncThunk(
     } catch (err) {
       // Note: this is an example assuming the usage of axios. Other fetching libraries would likely have different implementations
       if (!err.response) {
-        throw err;
+        throw err
       }
 
       return rejectWithValue(err.response.data)
@@ -410,20 +410,20 @@ const usersSlice = createSlice({
   initialState: {
     entities: {},
     loading: 'idle',
-    error: null,
+    error: null
   },
   reducers: {},
   extraReducers: {
     [updateUser.fullfilled]: (state, action) => {
-      const user = action.payload;
-      state.entities[user.id] = user;
+      const user = action.payload
+      state.entities[user.id] = user
     },
     [updateUser.rejected]: (state, action) => {
       if (action.payload) {
         // if a rejected action has a payload, it means that it was returned with rejectWithValue
         state.error = action.payload.errorMessage
       } else {
-        state.error = action.error;
+        state.error = action.error
       }
     }
   }
@@ -434,18 +434,18 @@ const UsersComponent = () => {
   const dispatch = useDispatch()
 
   const updateUser = async userData => {
-      const resultAction = await dispatch(updateUser(userData))
-      if (updateUser.fulfilled.match(resultAction)) {
-        const user = unwrapResult(resultAction)
-        showToast('success', `Updated ${user.name}`)
+    const resultAction = await dispatch(updateUser(userData))
+    if (updateUser.fulfilled.match(resultAction)) {
+      const user = unwrapResult(resultAction)
+      showToast('success', `Updated ${user.name}`)
+    } else {
+      if (resultAction.payload) {
+        // This is assuming the api returned a 400 error with a body of { errorMessage: 'Validation errors', field_errors: [{ field_name: 'Should be a string' }]}
+        setErrors(resultAction.payload.field_errors)
       } else {
-        if (resultAction.payload) {
-          // This is assuming the api returned a 400 error with a body of { errorMessage: 'Validation errors', field_errors: [{ field_name: 'Should be a string' }]}
-          setErrors(resultAction.payload.field_errors)
-        } else {
-          showToast('error', `Update failed: ${resultAction.error}`)
-        }
+        showToast('error', `Update failed: ${resultAction.error}`)
       }
+    }
   }
 
   // render UI here
@@ -453,7 +453,7 @@ const UsersComponent = () => {
 ```
 
 - TypeScript: Using rejectWithValue to access a custom rejected payload in a component
-_Note: this is a contrived example assuming our userAPI only ever throws a validation-specific errors_
+  _Note: this is a contrived example assuming our userAPI only ever throws a validation-specific errors_
 
 ```typescript
 import { createAsyncThunk, createSlice, unwrapResult } from '@reduxjs/toolkit'
@@ -477,28 +477,25 @@ interface UpdateUserResponse {
 }
 
 const updateUser = createAsyncThunk<
-    User,
-    Partial<User>,
-    {
-      rejectValue: ValidationErrors
-    }
-  >(
-  'users/update',
-  async (userData, { rejectWithValue }) => {
-    try {
-      const { id, ...data } = userData;
-      const response = await userAPI.updateById<UpdateUserResponse>(id, data)
-      return response.data.user
-    } catch (err) {
-      let error: AxiosError<ValidationErrors> = err; // cast the error for access
-      if (!error.response) {
-        throw err;
-      }
-      // We got validation errors, let's return those so we can reference in our component and set form errors
-      return rejectWithValue(error.response.data)
-    }
+  User,
+  Partial<User>,
+  {
+    rejectValue: ValidationErrors
   }
-)
+>('users/update', async (userData, { rejectWithValue }) => {
+  try {
+    const { id, ...data } = userData
+    const response = await userAPI.updateById<UpdateUserResponse>(id, data)
+    return response.data.user
+  } catch (err) {
+    let error: AxiosError<ValidationErrors> = err // cast the error for access
+    if (!error.response) {
+      throw err
+    }
+    // We got validation errors, let's return those so we can reference in our component and set form errors
+    return rejectWithValue(error.response.data)
+  }
+})
 
 interface UsersState {
   error: string | null
@@ -507,7 +504,7 @@ interface UsersState {
 
 const initialState: UsersState = {
   entities: {},
-  error: null,
+  error: null
 }
 
 const usersSlice = createSlice({
@@ -516,14 +513,14 @@ const usersSlice = createSlice({
   reducers: {},
   extraReducers: builder => {
     builder.addCase(updateUser.fulfilled, (state, { payload }) => {
-      state.entities[payload.id] = payload;
+      state.entities[payload.id] = payload
     })
     builder.addCase(updateUser.rejected, (state, action) => {
       if (action.payload) {
         // Being that we passed in ValidationErrors to rejectType in `createAsyncThunk`, the payload will be available here.
         state.error = action.payload.errorMessage
       } else {
-        state.error = action.error;
+        state.error = action.error
       }
     })
   }
@@ -534,19 +531,19 @@ const UsersComponent = () => {
   const dispatch = useDispatch()
 
   const updateUser = async userData => {
-      const resultAction = await dispatch(updateUser(userData))
-      if (updateUser.fulfilled.match(resultAction)) {
-        // user will have a type signature of User as we passed that as the Returned parameter in createAsyncThunk
-        const user = unwrapResult(resultAction)
-        showToast('success', `Updated ${user.name}`)
+    const resultAction = await dispatch(updateUser(userData))
+    if (updateUser.fulfilled.match(resultAction)) {
+      // user will have a type signature of User as we passed that as the Returned parameter in createAsyncThunk
+      const user = unwrapResult(resultAction)
+      showToast('success', `Updated ${user.name}`)
+    } else {
+      if (resultAction.payload) {
+        // Being that we passed in ValidationErrors to rejectType in `createAsyncThunk`, those types will be available here.
+        setErrors(resultAction.payload.field_errors)
       } else {
-        if (resultAction.payload) {
-          // Being that we passed in ValidationErrors to rejectType in `createAsyncThunk`, those types will be available here.
-          setErrors(resultAction.payload.field_errors)
-        } else {
-          showToast('error', `Update failed: ${resultAction.error}`)
-        }
+        showToast('error', `Update failed: ${resultAction.error}`)
       }
+    }
   }
 
   // render UI here

--- a/docs/api/createAsyncThunk.md
+++ b/docs/api/createAsyncThunk.md
@@ -453,7 +453,7 @@ const UsersComponent = () => {
 ```
 
 - TypeScript: Using rejectWithValue to access a custom rejected payload in a component
-  _Note: this is a contrived example assuming our userAPI only ever throws a validation-specific errors_
+  _Note: this is a contrived example assuming our userAPI only ever throws validation-specific errors_
 
 ```typescript
 import { createAsyncThunk, createSlice, unwrapResult } from '@reduxjs/toolkit'
@@ -527,7 +527,7 @@ const usersSlice = createSlice({
 })
 
 const UsersComponent = () => {
-  const { users, loading, error } = useSelector(state => state.users)
+  const { users, loading, error } = useSelector( (state: RootState) => state.users)
   const dispatch = useDispatch()
 
   const updateUser = async userData => {

--- a/docs/api/createAsyncThunk.md
+++ b/docs/api/createAsyncThunk.md
@@ -391,7 +391,7 @@ import { userAPI } from './userAPI'
 const updateUser = createAsyncThunk(
   'users/update',
   async (userData, { rejectWithValue }) => {
-    const { id, ...fields } = userData;
+    const { id, ...fields } = userData
     try {
       const response = await userAPI.updateById(id, fields)
       return response.data.user
@@ -531,11 +531,16 @@ const usersSlice = createSlice({
 })
 
 const UsersComponent = () => {
-  const { users, loading, error } = useSelector((state: RootState) => state.users)
+  const { users, loading, error } = useSelector(
+    (state: RootState) => state.users
+  )
   const dispatch: AppDispatch = useDispatch()
 
   // This is an example of an onSubmit handler using Formik meant to demonstrate accessing the payload of the rejected action
-  const handleUpdateUser = async (values: FormValues, formikHelpers: FormikHelpers<FormValues>) => {
+  const handleUpdateUser = async (
+    values: FormValues,
+    formikHelpers: FormikHelpers<FormValues>
+  ) => {
     const resultAction = await dispatch(updateUser(values))
     if (updateUser.fulfilled.match(resultAction)) {
       // user will have a type signature of User as we passed that as the Returned parameter in createAsyncThunk

--- a/docs/api/createAsyncThunk.md
+++ b/docs/api/createAsyncThunk.md
@@ -64,7 +64,7 @@ For example, a `type` argument of `'users/requestStatus'` will generate these ac
 
 ### `payloadCreator`
 
-A callback function that should return a promise containing the result of some asynchronous logic. It may also return a value synchronously. If there is an error, it should return a rejected promise containing either an `Error` instance or a plain value such as a descriptive error message.
+A callback function that should return a promise containing the result of some asynchronous logic. It may also return a value synchronously. If there is an error, it should return a rejected promise containing one of the following: an `Error` instance, a plain value such as a descriptive error message, or a manually rejected error with a defined payload.
 
 The `payloadCreator` function can contain whatever logic you need to calculate an appropriate result. This could include a standard AJAX data fetch request, multiple AJAX calls with the results combined into a final value, interactions with React Native `AsyncStorage`, and so on.
 
@@ -77,6 +77,7 @@ The `payloadCreator` function will be called with two arguments:
   - `extra`: the "extra argument" given to the thunk middleware on setup, if available
   - `requestId`: a unique string ID value that was automatically generated to identify this request sequence
   - `signal`: an [`AbortController.signal` object](https://developer.mozilla.org/en-US/docs/Web/API/AbortController/signal) that may be used to see if another part of the app logic has marked this request as needing cancelation.
+  - `rejectWithValue`: rejectWithValue is a utility function that you can `return` in your action creator to return a rejected response with a defined payload. It will pass whatever value you give it and return it in the payload of the rejected action.
 
 The logic in the `payloadCreator` function may use any of these values as needed to calculate the result.
 
@@ -90,7 +91,8 @@ When dispatched, the thunk will:
 - call the `payloadCreator` callback and wait for the returned promise to settle
 - when the promise settles:
   - if the promise resolved successfully, dispatch the `fulfilled` action with the promise value as `action.payload`
-  - if the promise failed, dispatch the `rejected` action with a serialized version of the error value as `action.error`
+  - if the promise resolved successfully or failed, but was returned with `rejectWithValue(value)`, dispatch the `rejected` action with the value passed into `action.payload`  and 'Rejected' as `action.error.message`
+  - if the promise failed and was not handled with `rejectWithValue`, dispatch the `rejected` action with a serialized version of the error value as `action.error`
 - Return a fulfilled promise containing the final dispatched action (either the `fulfilled` or `rejected` action object)
 
 ## Promise Lifecycle Actions
@@ -99,7 +101,7 @@ When dispatched, the thunk will:
 
 The action creators will have these signatures:
 
-```ts
+```typescript
 interface SerializedError {
   name?: string
   message?: string
@@ -136,6 +138,17 @@ interface RejectedAction<ThunkArg> {
   }
 }
 
+interface RejectedWithValueAction<ThunkArg, RejectedValue> {
+  type: string
+  payload: RejectedValue
+  error: { message: 'Rejected' }
+  meta: {
+    requestId: string
+    arg: ThunkArg
+    aborted: boolean
+  }
+}
+
 type Pending = <ThunkArg>(
   requestId: string,
   arg: ThunkArg
@@ -151,6 +164,11 @@ type Rejected = <ThunkArg>(
   requestId: string,
   arg: ThunkArg
 ) => RejectedAction<ThunkArg>
+
+type RejectedWithValue = <ThunkArg, RejectedValue>(
+  requestId: string,
+  arg: ThunkArg
+) => RejectedWithValueAction<ThunkArg, RejectedValue>
 ```
 
 To handle these actions in your reducers, reference the action creators in `createReducer` or `createSlice` using either the object key notation or the "builder callback" notation:
@@ -299,7 +317,7 @@ const fetchUserById = createAsyncThunk(
 
 ## Examples
 
-Requesting a user by ID, with loading state, and only one request at a time:
+#### Requesting a user by ID, with loading state, and only one request at a time:
 
 ```js
 import { createAsyncThunk, createSlice, unwrapResult } from '@reduxjs/toolkit'
@@ -352,12 +370,182 @@ const UsersComponent = () => {
 
   const fetchOneUser = async userId => {
     try {
-      const resultAction = dispatch(fetchUserById(userId))
+      const resultAction = await dispatch(fetchUserById(userId))
       const user = unwrapResult(resultAction)
       showToast('success', `Fetched ${user.name}`)
     } catch (err) {
       showToast('error', `Fetch failed: ${err.message}`)
     }
+  }
+
+  // render UI here
+}
+```
+
+#### Using rejectWithValue to access a custom rejected payload in a component
+```js
+import { createAsyncThunk, createSlice, unwrapResult } from '@reduxjs/toolkit'
+import { userAPI } from './userAPI'
+
+const updateUser = createAsyncThunk(
+  'users/update',
+  async (userData, { rejectWithValue }) => {
+    try {
+      const response = await userAPI.updateById(userData)
+      return response.data.user
+    } catch (err) {
+      // Note: this is an example assuming the usage of axios. Other fetching libraries would likely have different implementations
+      if (!err.response) {
+        throw err;
+      }
+
+      return rejectWithValue(err.response.data)
+    }
+  }
+)
+
+const usersSlice = createSlice({
+  name: 'users',
+  initialState: {
+    entities: {},
+    loading: 'idle',
+    error: null,
+  },
+  reducers: {},
+  extraReducers: {
+    [updateUser.fullfilled]: (state, action) => {
+      const user = action.payload;
+      state.entities[user.id] = user;
+    },
+    [updateUser.rejected]: (state, action) => {
+      if (action.payload) {
+        // if a rejected action has a payload, it means that it was returned with rejectWithValue
+        state.error = action.payload.errorMessage
+      } else {
+        state.error = action.error;
+      }
+    }
+  }
+})
+
+const UsersComponent = () => {
+  const { users, loading, error } = useSelector(state => state.users)
+  const dispatch = useDispatch()
+
+  const updateUser = async userData => {
+      const resultAction = await dispatch(updateUser(userData))
+      if (updateUser.fulfilled.match(resultAction)) {
+        const user = unwrapResult(resultAction)
+        showToast('success', `Updated ${user.name}`)
+      } else {
+        if (resultAction.payload) {
+          // This is assuming the api returned a 400 error with a body of { errorMessage: 'Validation errors', field_errors: [{ field_name: 'Should be a string' }]}
+          setErrors(resultAction.payload.field_errors) 
+        } else {
+          showToast('error', `Update failed: ${resultAction.error}`)
+        }
+      }
+  }
+
+  // render UI here
+}
+```
+
+
+#### TypeScript: Using rejectWithValue to access a custom rejected payload in a component
+_Note: this is a contrived example assuming our userAPI only ever throws a validation-specific errors_
+```typescript
+import { createAsyncThunk, createSlice, unwrapResult } from '@reduxjs/toolkit'
+import { userAPI } from './userAPI'
+
+// Sample types that will be used
+interface User {
+  first_name: string
+  last_name: string
+  email: string
+}
+
+interface ValidationErrors {
+  errorMessage: string
+  field_errors: Record<string, string>
+}
+
+interface UpdateUserResponse {
+  user: User
+  success: boolean
+}
+
+const updateUser = createAsyncThunk<
+    User,
+    Partial<User>,
+    {
+      rejectValue: ValidationErrors
+    }
+  >(
+  'users/update',
+  async (userData, { rejectWithValue }) => {
+    try {
+      const { id, ...data } = userData;
+      const response = await userAPI.updateById<UpdateUserResponse>(id, data)
+      return response.data.user
+    } catch (err) {
+      let error: AxiosError<ValidationErrors> = err; // cast the error for access
+      if (!error.response) {
+        throw err;
+      }
+      // We got validation errors, let's return those so we can reference in our component and set form errors
+      return rejectWithValue(error.response.data)
+    }
+  }
+)
+
+interface UsersState {
+  error: string | null
+  entities: Record<string, User>
+}
+
+const initialState: UsersState = {
+  entities: {},
+  error: null,
+}
+
+const usersSlice = createSlice({
+  name: 'users',
+  initialState,
+  reducers: {},
+  extraReducers: builder => {
+    builder.addCase(updateUser.fulfilled, (state, { payload }) => {
+      state.entities[payload.id] = payload;
+    })
+    builder.addCase(updateUser.rejected, (state, action) => {
+      if (action.payload) {
+        // Being that we passed in ValidationErrors to rejectType in `createAsyncThunk`, the payload will be available here.
+        state.error = action.payload.errorMessage
+      } else {
+        state.error = action.error;
+      }
+    })
+  }
+})
+
+const UsersComponent = () => {
+  const { users, loading, error } = useSelector(state => state.users)
+  const dispatch = useDispatch()
+
+  const updateUser = async userData => {
+      const resultAction = await dispatch(updateUser(userData))
+      if (updateUser.fulfilled.match(resultAction)) {
+        // user will have a type signature of User as we passed that as the Returned parameter in createAsyncThunk
+        const user = unwrapResult(resultAction)
+        showToast('success', `Updated ${user.name}`)
+      } else {
+        if (resultAction.payload) {
+          // Being that we passed in ValidationErrors to rejectType in `createAsyncThunk`, those types will be available here.
+          setErrors(resultAction.payload.field_errors) 
+        } else {
+          showToast('error', `Update failed: ${resultAction.error}`)
+        }
+      }
   }
 
   // render UI here

--- a/docs/api/createAsyncThunk.md
+++ b/docs/api/createAsyncThunk.md
@@ -317,7 +317,7 @@ const fetchUserById = createAsyncThunk(
 
 ## Examples
 
-#### Requesting a user by ID, with loading state, and only one request at a time:
+- Requesting a user by ID, with loading state, and only one request at a time:
 
 ```js
 import { createAsyncThunk, createSlice, unwrapResult } from '@reduxjs/toolkit'
@@ -382,7 +382,8 @@ const UsersComponent = () => {
 }
 ```
 
-#### Using rejectWithValue to access a custom rejected payload in a component
+- Using rejectWithValue to access a custom rejected payload in a component
+
 ```js
 import { createAsyncThunk, createSlice, unwrapResult } from '@reduxjs/toolkit'
 import { userAPI } from './userAPI'
@@ -440,7 +441,7 @@ const UsersComponent = () => {
       } else {
         if (resultAction.payload) {
           // This is assuming the api returned a 400 error with a body of { errorMessage: 'Validation errors', field_errors: [{ field_name: 'Should be a string' }]}
-          setErrors(resultAction.payload.field_errors) 
+          setErrors(resultAction.payload.field_errors)
         } else {
           showToast('error', `Update failed: ${resultAction.error}`)
         }
@@ -451,9 +452,9 @@ const UsersComponent = () => {
 }
 ```
 
-
-#### TypeScript: Using rejectWithValue to access a custom rejected payload in a component
+- TypeScript: Using rejectWithValue to access a custom rejected payload in a component
 _Note: this is a contrived example assuming our userAPI only ever throws a validation-specific errors_
+
 ```typescript
 import { createAsyncThunk, createSlice, unwrapResult } from '@reduxjs/toolkit'
 import { userAPI } from './userAPI'
@@ -541,7 +542,7 @@ const UsersComponent = () => {
       } else {
         if (resultAction.payload) {
           // Being that we passed in ValidationErrors to rejectType in `createAsyncThunk`, those types will be available here.
-          setErrors(resultAction.payload.field_errors) 
+          setErrors(resultAction.payload.field_errors)
         } else {
           showToast('error', `Update failed: ${resultAction.error}`)
         }

--- a/docs/usage/usage-with-typescript.md
+++ b/docs/usage/usage-with-typescript.md
@@ -447,7 +447,7 @@ const fetchUserById = createAsyncThunk<
 })
 ```
 
-If you are performing a request that you know will typically either be a success or have an expected error format, you can pass in a type to `rejectValue` and  `return rejectWithValue(knownPayload)`. This allows you to reference the error payload in the reducer as well as in a component
+If you are performing a request that you know will typically either be a success or have an expected error format, you can pass in a type to `rejectValue` and `return rejectWithValue(knownPayload)`. This allows you to reference the error payload in the reducer as well as in a component
 
 ```ts
 interface MyKnownError {
@@ -468,7 +468,7 @@ const updateUserById = createAsyncThunk<
     rejectValue: MyKnownError
   }
 >('users/updateById', async (user, thunkApi) => {
-  const { id, ...userData } = user;
+  const { id, ...userData } = user
   const response = await fetch(`https://reqres.in/api/users/${id}`, {
     method: 'PUT',
     headers: {
@@ -478,7 +478,7 @@ const updateUserById = createAsyncThunk<
   })
   if (response.status === 400) {
     // Return any known error for future handling
-    return thunkApi.rejectWithValue(await response.json() as MyKnownError);
+    return thunkApi.rejectWithValue((await response.json()) as MyKnownError)
   }
   return (await response.json()) as MyData
 })

--- a/docs/usage/usage-with-typescript.md
+++ b/docs/usage/usage-with-typescript.md
@@ -447,7 +447,7 @@ const fetchUserById = createAsyncThunk<
 })
 ```
 
-If you are performing a request that you know will typically either be a success or have an expected error format, you can pass in a type to `rejectValue` and `return rejectWithValue(knownPayload)`. This allows you to reference the error payload in the reducer as well as in a component
+If you are performing a request that you know will typically either be a success or have an expected error format, you can pass in a type to `rejectValue` and `return rejectWithValue(knownPayload)` in the action creator. This allows you to reference the error payload in the reducer as well as in a component after dispatching the `createAsyncThunk` action.
 
 ```ts
 interface MyKnownError {
@@ -456,12 +456,11 @@ interface MyKnownError {
 
 const updateUserById = createAsyncThunk<
   // Return type of the payload creator
-  Promise<MyData>,
+  MyData,
   // First argument to the payload creator
   number,
+  // Types for ThunkAPI
   {
-    dispatch: AppDispatch
-    state: State
     extra: {
       jwt: string
     }

--- a/docs/usage/usage-with-typescript.md
+++ b/docs/usage/usage-with-typescript.md
@@ -427,7 +427,7 @@ To define the types for these arguments, pass an object as the third generic arg
 ```ts
 const fetchUserById = createAsyncThunk<
   // Return type of the payload creator
-  Promise<MyData>,
+  MyData,
   // First argument to the payload creator
   number,
   {

--- a/docs/usage/usage-with-typescript.md
+++ b/docs/usage/usage-with-typescript.md
@@ -504,7 +504,7 @@ const usersSlice = createSlice({
     })
     builder.addCase(updateUserById.rejected, (state, action) => {
       if (action.payload) {
-        // Being that we passed in MyKnownError to rejectType in `updateUserById`, the type information will be available here.
+        // Since we passed in `MyKnownError` to `rejectType` in `updateUserById`, the type information will be available here.
         state.error = action.payload.errorMessage
       } else {
         state.error = action.error
@@ -525,7 +525,7 @@ const updateUser = async userData => {
     showToast('success', `Updated ${user.name}`)
   } else {
     if (resultAction.payload) {
-      // Being that we passed in MyKnownError to rejectType in `updateUserById`, the type information will be available here.
+      // Since we passed in `MyKnownError` to `rejectType` in `updateUserById`, the type information will be available here.
       showToast('error', `Update failed: ${rersultAction.payload.errorMessage}`)
     } else {
       showToast('error', `Update failed: ${resultAction.error.message}`)

--- a/docs/usage/usage-with-typescript.md
+++ b/docs/usage/usage-with-typescript.md
@@ -454,12 +454,18 @@ interface MyKnownError {
   errorMessage: string
   // ...
 }
+interface UserAttributes {
+  id: string
+  first_name: string
+  last_name: string
+  email: string
+}
 
-const updateUserById = createAsyncThunk<
+const updateUser = createAsyncThunk<
   // Return type of the payload creator
   MyData,
   // First argument to the payload creator
-  { id: string; first_name: string; last_name: string; email: string },
+  UserAttributes,
   // Types for ThunkAPI
   {
     extra: {
@@ -467,7 +473,7 @@ const updateUserById = createAsyncThunk<
     }
     rejectValue: MyKnownError
   }
->('users/updateById', async (user, thunkApi) => {
+>('users/update', async (user, thunkApi) => {
   const { id, ...userData } = user
   const response = await fetch(`https://reqres.in/api/users/${id}`, {
     method: 'PUT',
@@ -499,12 +505,12 @@ const usersSlice = createSlice({
   },
   reducers: {},
   extraReducers: builder => {
-    builder.addCase(updateUserById.fulfilled, (state, { payload }) => {
+    builder.addCase(updateUser.fulfilled, (state, { payload }) => {
       state.entities[payload.id] = payload
     })
-    builder.addCase(updateUserById.rejected, (state, action) => {
+    builder.addCase(updateUser.rejected, (state, action) => {
       if (action.payload) {
-        // Since we passed in `MyKnownError` to `rejectType` in `updateUserById`, the type information will be available here.
+        // Since we passed in `MyKnownError` to `rejectType` in `updateUser`, the type information will be available here.
         state.error = action.payload.errorMessage
       } else {
         state.error = action.error
@@ -517,16 +523,16 @@ const usersSlice = createSlice({
 - In a component
 
 ```ts
-const updateUser = async userData => {
-  const { id, ...userFields } = userData
-  const resultAction = await dispatch(updateUserById(userFields))
+const handleUpdateUser = async userData => {
+  const resultAction = await dispatch(updateUser(userData))
   if (updateUser.fulfilled.match(resultAction)) {
     const user = unwrapResult(resultAction)
     showToast('success', `Updated ${user.name}`)
   } else {
     if (resultAction.payload) {
-      // Since we passed in `MyKnownError` to `rejectType` in `updateUserById`, the type information will be available here.
-      showToast('error', `Update failed: ${rersultAction.payload.errorMessage}`)
+      // Since we passed in `MyKnownError` to `rejectType` in `updateUser`, the type information will be available here.
+      // Note: this would also be a good place to do any handling that relies on the `rejectedWithValue` payload, such as setting field errors
+      showToast('error', `Update failed: ${resultAction.payload.errorMessage}`)
     } else {
       showToast('error', `Update failed: ${resultAction.error.message}`)
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -3724,7 +3724,8 @@
           "version": "2.1.1",
           "resolved": false,
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3748,13 +3749,15 @@
           "version": "1.0.0",
           "resolved": false,
           "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "resolved": false,
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3771,19 +3774,22 @@
           "version": "1.1.0",
           "resolved": false,
           "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "resolved": false,
           "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "resolved": false,
           "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3914,7 +3920,8 @@
           "version": "2.0.3",
           "resolved": false,
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3928,6 +3935,7 @@
           "resolved": false,
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3944,6 +3952,7 @@
           "resolved": false,
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3952,13 +3961,15 @@
           "version": "0.0.8",
           "resolved": false,
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "resolved": false,
           "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -3979,6 +3990,7 @@
           "resolved": false,
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4067,7 +4079,8 @@
           "version": "1.0.1",
           "resolved": false,
           "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4081,6 +4094,7 @@
           "resolved": false,
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4176,7 +4190,8 @@
           "version": "5.1.2",
           "resolved": false,
           "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -4218,6 +4233,7 @@
           "resolved": false,
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -4239,6 +4255,7 @@
           "resolved": false,
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -4287,13 +4304,15 @@
           "version": "1.0.2",
           "resolved": false,
           "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "resolved": false,
           "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -3724,8 +3724,7 @@
           "version": "2.1.1",
           "resolved": false,
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3749,15 +3748,13 @@
           "version": "1.0.0",
           "resolved": false,
           "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "resolved": false,
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3774,22 +3771,19 @@
           "version": "1.1.0",
           "resolved": false,
           "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "resolved": false,
           "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "resolved": false,
           "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3920,8 +3914,7 @@
           "version": "2.0.3",
           "resolved": false,
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3935,7 +3928,6 @@
           "resolved": false,
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3952,7 +3944,6 @@
           "resolved": false,
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3961,15 +3952,13 @@
           "version": "0.0.8",
           "resolved": false,
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "resolved": false,
           "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -3990,7 +3979,6 @@
           "resolved": false,
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4079,8 +4067,7 @@
           "version": "1.0.1",
           "resolved": false,
           "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4094,7 +4081,6 @@
           "resolved": false,
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4190,8 +4176,7 @@
           "version": "5.1.2",
           "resolved": false,
           "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -4233,7 +4218,6 @@
           "resolved": false,
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -4255,7 +4239,6 @@
           "resolved": false,
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -4304,15 +4287,13 @@
           "version": "1.0.2",
           "resolved": false,
           "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "resolved": false,
           "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },

--- a/src/createAsyncThunk.ts
+++ b/src/createAsyncThunk.ts
@@ -157,7 +157,7 @@ export function createAsyncThunk<
       const aborted = !!error && error.name === 'AbortError'
       return {
         payload,
-        error: miniSerializeError(error) || { message: 'Rejected' },
+        error: payload ? { message: 'Rejected' } : miniSerializeError(error),
         meta: {
           arg,
           requestId,

--- a/src/createAsyncThunk.ts
+++ b/src/createAsyncThunk.ts
@@ -157,7 +157,7 @@ export function createAsyncThunk<
       const aborted = !!error && error.name === 'AbortError'
       return {
         payload,
-        error: payload ? { message: 'Rejected' } : miniSerializeError(error),
+        error: miniSerializeError(error || 'Rejected'),
         meta: {
           arg,
           requestId,


### PR DESCRIPTION
- Adds tests to show that miniSerializeError works when there is no payload
- Updates documentation to explain the purpose of rejectWithValue
- Adds two examples, one in JS one in TS for usage